### PR TITLE
feat: use new swf layout with contributors at backcover

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "metanorma-cli", github: "metanorma/metanorma-cli", branch: "main"
 
-gem "metanorma-taste", github: "metanorma/metanorma-taste", branch: "swf_update"
+gem "metanorma-taste", github: "metanorma/metanorma-taste", branch: "main"
 gem "metanorma-ribose", github: "metanorma/metanorma-ribose", branch: "main"
 gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "main"
 gem "sassc-embedded"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source "https://rubygems.org"
 
-gem "metanorma-cli"
+gem "metanorma-cli", github: "metanorma/metanorma-cli", branch: "main"
 
-gem "metanorma-taste", github: "metanorma/metanorma-taste", branch: "csa"
-gem "metanorma-ribose", github: "metanorma/metanorma-ribose"
+gem "metanorma-taste", github: "metanorma/metanorma-taste", branch: "swf_update"
+gem "metanorma-ribose", github: "metanorma/metanorma-ribose", branch: "main"
+gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "main"
 gem "sassc-embedded"

--- a/sources/document.adoc
+++ b/sources/document.adoc
@@ -13,13 +13,37 @@
 :doctype: standard
 :status: published
 :docidentifier: SWF 3:2025 (0.1.0)
-:surname: Sabadello
-:givenname: Markus
-:role: editor
 :imagesdir: images
 :local-cache-only:
 :toc-figures: true
 :toc-tables: true
+:comment: [backcover] leadership team list below
+:fullname: Gabriel René
+:role-description: leadership
+:contributor-position: Executive Director / Founder
+:fullname_2: Dan Mapes
+:role-description_2: leadership
+:contributor-position_2: Managing Director / Founder
+:fullname_3: Bastiaan den Braber
+:role-description_3: leadership
+:contributor-position_3: Director of Operations
+:fullname_4: George Percivall
+:role-description_4: leadership
+:contributor-position_4: Distinguished Engineering Fellow
+:fullname_5: Dan Richardson
+:role-description_5: leadership
+:contributor-position_5: Director of Market Analysis
+:fullname_6: Dr. Sarah Grace Manski
+:role-description_6: leadership
+:contributor-position_6: Senior Ethics Advisor
+:comment: [backcover] participants list below
+:fullname_7: Markus Sabadello
+:fullname_8: Gabriel René
+:fullname_9: Dan Mapes
+:fullname_10: Bastiaan den Braber
+:fullname_11: George Percivall
+:fullname_12: Dan Richardson
+:fullname_13: Dr. Sarah Grace Manski
 
 include::sections/00-abstract.adoc[]
 


### PR DESCRIPTION
This PR adopts the new SWF layout and assigns new attributes, with a configurable backcover showing contributors and leadership.

[swf-3-2025-0.1.0.pdf](https://github.com/user-attachments/files/22378035/swf-3-2025-0.1.0.pdf)

FYI @percivall for review and merge.