### PR TITLE
fix: gha on github pages

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -50,8 +50,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           agree-to-terms: true
-          destination: artifact
-          artifact-name: draft
           use-bundler: true
 
   deploy:


### PR DESCRIPTION
@percivall this fixes the GitHub Actions failure. You might need to go to "Settings > Pages" and set deployment to "GitHub Actions":

<img width="731" height="512" alt="Screenshot 2025-09-20 at 1 53 56 PM" src="https://github.com/user-attachments/assets/fbfe5839-2795-4fb5-b875-5d9315e22cfe" />
